### PR TITLE
Fix GithubStrategy to packagist changes

### DIFF
--- a/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
@@ -146,7 +146,7 @@ class UpdaterGithubStrategyTest extends TestCase
                         ],
                     ],
                     [
-                        'version' => '1.0.0'
+                        'version' => '1.0.0',
                     ],
                 ],
             ],

--- a/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
@@ -139,12 +139,14 @@ class UpdaterGithubStrategyTest extends TestCase
         file_put_contents($this->tmp.'/packages.json', json_encode([
             'packages' => [
                 'humbug/test-phar' => [
-                    '1.0.1' => [
+                    [
+                        'version' => '1.0.1',
                         'source' => [
                             'url' => 'file://'.$this->tmp.'.git',
                         ],
                     ],
-                    '1.0.0' => [
+                    [
+                        'version' => '1.0.0'
                     ],
                 ],
             ],


### PR DESCRIPTION
The versions are not indexed by their version anymore. See https://packagist.org/p2/laravel-zero/phar-updater.json