### PR TITLE
fix: getCurrentRemoteVersion() if last is unstable

### DIFF
--- a/src/Strategy/GithubStrategy.php
+++ b/src/Strategy/GithubStrategy.php
@@ -116,9 +116,10 @@ class GithubStrategy implements StrategyInterface
          * Setup remote URL if there's an actual version to download.
          */
         if (! empty($this->remoteVersion)) {
-            $chosenVersion = array_filter($package['packages'][$this->getPackageName()], function (array $package) {
+            $remoteVersionPackages = array_filter($package['packages'][$this->getPackageName()], function (array $package) {
                 return $package['version'] === $this->remoteVersion;
-            })[0];
+            });
+            $chosenVersion = reset($remoteVersionPackages);
 
             $this->remoteUrl = $this->getDownloadUrl($chosenVersion);
         }

--- a/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
+++ b/tests/Humbug/Test/SelfUpdate/UpdaterGithubStrategyTest.php
@@ -141,6 +141,9 @@ class UpdaterGithubStrategyTest extends TestCase
             'packages' => [
                 'humbug/test-phar' => [
                     [
+                        'version' => '2.0.0-beta.1',
+                    ],
+                    [
                         'version' => '1.0.1',
                         'source' => [
                             'url' => 'file://'.$this->tmp.'.git',


### PR DESCRIPTION
In case of the last version is unstable (dev, beta, etc.) this one is ommitted by getCurrentRemoteVersion().

To do that the packages array is filtered and the index 0 is returned but it should be the index 1 (because the index 0 don't exist). So to prevent that bahavior the best way is to reset the returned array.