### PR TITLE
Update Packagist URL

### DIFF
--- a/src/Strategy/GithubStrategy.php
+++ b/src/Strategy/GithubStrategy.php
@@ -23,7 +23,7 @@ use function file_get_contents;
 
 class GithubStrategy implements StrategyInterface
 {
-    const API_URL = 'https://packagist.org/p2/%s.json';
+    const API_URL = 'https://repo.packagist.org/p2/%s.json';
 
     const STABLE = 'stable';
 


### PR DESCRIPTION
According to https://github.com/composer/packagist/issues/1524, we should use repo.packagist.org when fetching package data.